### PR TITLE
[RTN] Fix typo: "h" -> "hc" & "ds" -> "s"

### DIFF
--- a/text/0000-return-type-notation.md
+++ b/text/0000-return-type-notation.md
@@ -789,7 +789,7 @@ where
     typeof {
         let hc: &'a mut H;
         let s: Server;        
-        H::check(h, ds)
+        H::check(hc, s)
     }: Send,
 ```
 


### PR DESCRIPTION
Fix the example, I change the identifiers. 